### PR TITLE
Removed example config MicroserviceHelloWorldController from application.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 # trade-reporting-extracts
 
-This is a placeholder README.md for a new repository
+A backend service for the Trade Reporting Extracts project, which serves to
+* Send requests to customs data store for fetching the trade reports requested by users.
+
 
 ### License
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,14 +49,6 @@ play.http.router = prod.Routes
 # auditing (transaction monitoring) enabled.
 # The below controllers are the default exceptions to this rule.
 
-controllers {
-  uk.gov.hmrc.tradereportingextracts.controllers.MicroserviceHelloWorldController = {
-    needsAuth = false
-    needsLogging = false
-    needsAuditing = false
-  }
-}
-
 # Microservice specific config
 
 mongodb {


### PR DESCRIPTION
this change has been made following the PR bot issues suggestions.

MicroserviceHelloWorldController is an example controller and never used. config can be added to other controllers when required.