### PR TITLE
TRE-601 return updated report requests on failure from EISservice

### DIFF
--- a/app/uk/gov/hmrc/tradereportingextracts/services/EisService.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/services/EisService.scala
@@ -94,9 +94,7 @@ class EisService @Inject() (
                     statusType = EisReportStatusRequest.StatusType.ERROR
                   )
               )
-              reportRequestService.update(updatedRequest).flatMap { _ =>
-                Future.failed(UpstreamErrorResponse(response.body, status))
-              }
+              reportRequestService.update(updatedRequest).map(_ => updatedRequest)
           }
         }
     }

--- a/test/uk/gov/hmrc/tradereportingextracts/services/EisServiceSpec.scala
+++ b/test/uk/gov/hmrc/tradereportingextracts/services/EisServiceSpec.scala
@@ -162,24 +162,29 @@ class EisServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
       }
     }
 
-    "fail with UpstreamErrorResponse if all retries exhausted with INTERNAL_SERVER_ERROR" in {
+    "return updated ReportRequest with FAILED status if all retries exhausted with INTERNAL_SERVER_ERROR" in {
       reset(mockConnector, mockReportRequestService)
+
       when(mockConnector.requestTraderReport(any(), any())(any()))
         .thenReturn(
           Future.successful(httpResponse(INTERNAL_SERVER_ERROR)),
           Future.successful(httpResponse(INTERNAL_SERVER_ERROR)),
           Future.successful(httpResponse(INTERNAL_SERVER_ERROR))
         )
+
       when(mockReportRequestService.update(any())(any()))
         .thenReturn(Future.successful(true))
 
       val result = service.requestTraderReport(eisReportRequest, reportRequest)
-      whenReady(result.failed) { ex =>
+
+      whenReady(result) { updatedReportRequest =>
         val captor = ArgumentCaptor.forClass(classOf[ReportRequest])
         verify(mockReportRequestService).update(captor.capture())(any())
 
         val persistedReportRequestAfterEis: ReportRequest = captor.getValue
-        persistedReportRequestAfterEis.notifications.head.copy(statusTimestamp = null) mustBe
+        val notification                                  = persistedReportRequestAfterEis.notifications.head
+
+        notification.copy(statusTimestamp = null) mustBe
           EisReportStatusRequest(
             applicationComponent = ApplicationComponent.TRE,
             statusCode = FAILED.toString,
@@ -188,8 +193,6 @@ class EisServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
             statusType = StatusType.ERROR
           )
 
-        ex                                              shouldBe a[UpstreamErrorResponse]
-        ex.asInstanceOf[UpstreamErrorResponse].reportAs shouldBe INTERNAL_SERVER_ERROR
         verify(mockConnector, times(3)).requestTraderReport(eqTo(eisReportRequest), eqTo(reportRequest.correlationId))(
           any()
         )


### PR DESCRIPTION
On failure scenario, returning the updated list of report requests to the controller as this was causing error screen after submission if EIS is down or badgateway error occurred. 
This is also required to audit the incomplete status of report request submission if the report request holds notifications with Failed status. 