### PR TITLE
TRE-585 company information API

### DIFF
--- a/app/uk/gov/hmrc/tradereportingextracts/controllers/CompanyInformationController.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/controllers/CompanyInformationController.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradereportingextracts.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, ControllerComponents}
+import uk.gov.hmrc.internalauth.client.*
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.tradereportingextracts.services.CompanyInformationService
+import uk.gov.hmrc.tradereportingextracts.utils.PermissionsUtil.readPermission
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CompanyInformationController @Inject() (
+  cc: ControllerComponents,
+  auth: BackendAuthComponents,
+  companyInformationService: CompanyInformationService
+)(using ec: ExecutionContext)
+    extends BackendController(cc) {
+
+  def getCompanyInformation: Action[JsValue] =
+    auth.authorizedAction(readPermission).async(parse.json) { implicit request =>
+      (request.body \ "eori").asOpt[String] match {
+        case Some(eori) =>
+          companyInformationService.getVisibleCompanyInformation(eori).map { info =>
+            Ok(Json.toJson(info))
+          }
+
+        case None =>
+          Future.successful(BadRequest(Json.obj("error" -> "Missing or invalid EORI in request body")))
+      }
+    }
+}

--- a/app/uk/gov/hmrc/tradereportingextracts/services/CompanyInformationService.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/services/CompanyInformationService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradereportingextracts.services
+
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.tradereportingextracts.connectors.CustomsDataStoreConnector
+import uk.gov.hmrc.tradereportingextracts.models.CompanyInformation
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CompanyInformationService @Inject() (
+  connector: CustomsDataStoreConnector
+)(implicit ec: ExecutionContext) {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  def getVisibleCompanyInformation(eori: String): Future[CompanyInformation] =
+    connector.getCompanyInformation(eori)
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,3 +22,5 @@ GET   /trade-reporting-extracts/report-submission-limit/:eori   uk.gov.hmrc.trad
 GET         /trade-reporting-extracts/eori/get-user-detail                    uk.gov.hmrc.tradereportingextracts.controllers.UserController.getUserAndEmail
 
 GET         /trade-reporting-extracts/downloaded-audit                    uk.gov.hmrc.tradereportingextracts.controllers.AvailableReportController.auditReportDownload()
+
+POST        /trade-reporting-extracts/company-information                 uk.gov.hmrc.tradereportingextracts.controllers.CompanyInformationController.getCompanyInformation

--- a/test/uk/gov/hmrc/tradereportingextracts/controllers/CompanyInformationControllerSpec.scala
+++ b/test/uk/gov/hmrc/tradereportingextracts/controllers/CompanyInformationControllerSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradereportingextracts.controllers
+
+import org.mockito.Mockito.when
+import play.api.libs.json.Json
+import play.api.test.Helpers.*
+import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.internalauth.client.Retrieval.EmptyRetrieval
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
+import uk.gov.hmrc.internalauth.client.*
+import uk.gov.hmrc.tradereportingextracts.models.{AddressInformation, CompanyInformation}
+import uk.gov.hmrc.tradereportingextracts.services.CompanyInformationService
+import uk.gov.hmrc.tradereportingextracts.utils.SpecBase
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CompanyInformationControllerSpec extends SpecBase {
+
+  implicit val ec: ExecutionContext         = ExecutionContext.Implicits.global
+  private val mockCompanyInformationService = mock[CompanyInformationService]
+  private val mockStubBehaviour             = mock[StubBehaviour]
+
+  private val backendAuthComponents: BackendAuthComponents =
+    BackendAuthComponentsStub(mockStubBehaviour)(Helpers.stubControllerComponents())
+
+  private val controller = new CompanyInformationController(
+    Helpers.stubControllerComponents(),
+    backendAuthComponents,
+    mockCompanyInformationService
+  )
+
+  val permission = Predicate.Permission(
+    Resource(ResourceType("trade-reporting-extracts"), ResourceLocation("trade-reporting-extracts/*")),
+    IAAction("READ")
+  )
+
+  "CompanyInformationController.getCompanyInformation" should {
+
+    "return 200 OK with CompanyInformation when valid EORI is provided" in {
+      val eori        = "GB123456789000"
+      val companyInfo = CompanyInformation(
+        name = "Acme Ltd",
+        consent = "1",
+        address = AddressInformation("123 Street", "City", Some("AB12 3CD"), "UK")
+      )
+
+      when(mockCompanyInformationService.getVisibleCompanyInformation(eori))
+        .thenReturn(Future.successful(companyInfo))
+      when(mockStubBehaviour.stubAuth(Some(permission), EmptyRetrieval))
+        .thenReturn(Future.successful(EmptyRetrieval))
+
+      val request = FakeRequest(POST, routes.CompanyInformationController.getCompanyInformation.url)
+        .withHeaders("Content-Type" -> "application/json", AUTHORIZATION -> "Bearer token")
+        .withBody(Json.obj("eori" -> eori))
+
+      val result = controller.getCompanyInformation.apply(request)
+
+      status(result)        shouldBe OK
+      contentAsJson(result) shouldBe Json.toJson(companyInfo)
+    }
+
+    "return 400 BadRequest when EORI is missing" in {
+      when(mockStubBehaviour.stubAuth(Some(permission), EmptyRetrieval))
+        .thenReturn(Future.successful(EmptyRetrieval))
+
+      val request = FakeRequest(POST, routes.CompanyInformationController.getCompanyInformation.url)
+        .withHeaders("Content-Type" -> "application/json", AUTHORIZATION -> "Bearer token")
+        .withBody(Json.obj("wrongField" -> "value"))
+
+      val result = controller.getCompanyInformation.apply(request)
+
+      status(result)        shouldBe BAD_REQUEST
+      contentAsString(result) should include("Missing or invalid EORI in request body")
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/tradereportingextracts/services/CompanyInformationServiceSpec.scala
+++ b/test/uk/gov/hmrc/tradereportingextracts/services/CompanyInformationServiceSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradereportingextracts.services
+
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito.*
+
+import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.tradereportingextracts.connectors.CustomsDataStoreConnector
+import uk.gov.hmrc.tradereportingextracts.models.{AddressInformation, CompanyInformation}
+
+class CompanyInformationServiceSpec extends AsyncWordSpec with Matchers with MockitoSugar {
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
+
+  val mockConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
+  val service                                  = new CompanyInformationService(mockConnector)
+
+  val eori                            = "GB123456789000"
+  val companyInfo: CompanyInformation = CompanyInformation(
+    name = "Acme Ltd",
+    consent = "1",
+    address = AddressInformation("123 Street", "City", Some("AB12 3CD"), "UK")
+  )
+
+  "CompanyInformationService.getVisibleCompanyInformation" should {
+
+    "return CompanyInformation when connector returns successfully" in {
+      when(mockConnector.getCompanyInformation(eori)).thenReturn(Future.successful(companyInfo))
+
+      service.getVisibleCompanyInformation(eori).map { result =>
+        result shouldBe companyInfo
+      }
+    }
+
+    "fail when connector throws an exception" in {
+      val exception = new RuntimeException("Service failure")
+      when(mockConnector.getCompanyInformation(eori)).thenReturn(Future.failed(exception))
+
+      recoverToExceptionIf[RuntimeException] {
+        service.getVisibleCompanyInformation(eori)
+      }.map { ex =>
+        ex.getMessage shouldBe "Service failure"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### **Company Information API** 

- To be used to check if an EORI number is a valid one or not 
- To be used to to fetch business information from CDS