### PR TITLE
TRE-1021 fix bug Complete reports are not sending emails

### DIFF
--- a/app/uk/gov/hmrc/tradereportingextracts/models/ReportRequest.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/models/ReportRequest.scala
@@ -44,7 +44,7 @@ case class ReportRequest(
   updateDate: Instant
 ) {
 
-  def isReportStatusComplete(): Boolean =
+  def isReportStatusComplete: Boolean =
     fileNotifications.exists { notifications =>
       val notificationsCount = notifications.size
       val lastNotification   = notifications.find(_.reportLastFile == "true")

--- a/app/uk/gov/hmrc/tradereportingextracts/repositories/ReportRequestRepository.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/repositories/ReportRequestRepository.scala
@@ -21,7 +21,7 @@ import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Indexes}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import uk.gov.hmrc.play.http.logging.Mdc
+import uk.gov.hmrc.mdc.Mdc
 import uk.gov.hmrc.tradereportingextracts.config.AppConfig
 import uk.gov.hmrc.tradereportingextracts.models.ReportRequest
 
@@ -112,14 +112,14 @@ class ReportRequestRepository @Inject() (appConfig: AppConfig, mongoComponent: M
       collection
         .find(Filters.in("requesterEORI", eoriHistory*))
         .toFuture()
-        .map(_.filter(!_.isReportStatusComplete()))
+        .map(_.filter(!_.isReportStatusComplete))
     }
 
   def getAvailableReports(eori: String)(using ec: ExecutionContext): Future[Seq[ReportRequest]] = Mdc.preservingMdc {
     collection
       .find(Filters.equal("requesterEORI", eori))
       .toFuture()
-      .map(_.filter(_.isReportStatusComplete()))
+      .map(_.filter(_.isReportStatusComplete))
   }
 
   def getAvailableReportsByHistory(eoriHistory: Seq[String])(using ec: ExecutionContext): Future[Seq[ReportRequest]] =
@@ -127,7 +127,7 @@ class ReportRequestRepository @Inject() (appConfig: AppConfig, mongoComponent: M
       collection
         .find(Filters.in("requesterEORI", eoriHistory*))
         .toFuture()
-        .map(_.filter(_.isReportStatusComplete()))
+        .map(_.filter(_.isReportStatusComplete))
     }
 
   def countAvailableReports(eori: String)(using ec: ExecutionContext): Future[Long] = Mdc.preservingMdc {
@@ -135,7 +135,7 @@ class ReportRequestRepository @Inject() (appConfig: AppConfig, mongoComponent: M
       .find(Filters.equal("requesterEORI", eori))
       .toFuture()
       .map { reportRequests =>
-        reportRequests.count(_.isReportStatusComplete())
+        reportRequests.count(_.isReportStatusComplete)
       }
   }
 

--- a/app/uk/gov/hmrc/tradereportingextracts/services/FileNotificationService.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/services/FileNotificationService.scala
@@ -22,7 +22,7 @@ import play.api.http.Status.{BAD_REQUEST, CREATED, NOT_FOUND}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tradereportingextracts.connectors.EmailConnector
 import uk.gov.hmrc.tradereportingextracts.models.sdes.{FileNotificationMetadata, FileNotificationResponse}
-import uk.gov.hmrc.tradereportingextracts.models.{ReportTypeName, FileNotification as TreFileNotification}
+import uk.gov.hmrc.tradereportingextracts.models.{FileNotification as TreFileNotification, ReportTypeName}
 
 import java.time.Instant
 import javax.inject.{Inject, Singleton}

--- a/app/uk/gov/hmrc/tradereportingextracts/services/FileNotificationService.scala
+++ b/app/uk/gov/hmrc/tradereportingextracts/services/FileNotificationService.scala
@@ -21,9 +21,8 @@ import play.api.http.Status
 import play.api.http.Status.{BAD_REQUEST, CREATED, NOT_FOUND}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tradereportingextracts.connectors.EmailConnector
-import uk.gov.hmrc.tradereportingextracts.models.ReportStatus.COMPLETE
 import uk.gov.hmrc.tradereportingextracts.models.sdes.{FileNotificationMetadata, FileNotificationResponse}
-import uk.gov.hmrc.tradereportingextracts.models.{FileNotification as TreFileNotification, ReportTypeName}
+import uk.gov.hmrc.tradereportingextracts.models.{ReportTypeName, FileNotification as TreFileNotification}
 
 import java.time.Instant
 import javax.inject.{Inject, Singleton}
@@ -52,7 +51,7 @@ class FileNotificationService @Inject() (reportRequestService: ReportRequestServ
             val updatedReportRequest     = reportRequest
               .copy(fileNotifications = updatedFileNotifications, updateDate = Instant.now())
             val maskedId                 = updatedReportRequest.reportRequestId.replaceFirst("^.{5}", "XXXXX")
-            if (reportRequestService.determineReportStatus(updatedReportRequest) == COMPLETE) {
+            if (updatedReportRequest.isReportStatusComplete) {
               for {
                 _ <- reportRequestService.update(updatedReportRequest)
                 _ <- updatedReportRequest.userEmail match {

--- a/test/uk/gov/hmrc/tradereportingextracts/services/FileNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/tradereportingextracts/services/FileNotificationServiceSpec.scala
@@ -27,9 +27,8 @@ import play.api.http.Status.{BAD_REQUEST, CREATED, NOT_FOUND}
 import uk.gov.hmrc.crypto.Sensitive.SensitiveString
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tradereportingextracts.connectors.EmailConnector
-import uk.gov.hmrc.tradereportingextracts.models.ReportStatus.COMPLETE
 import uk.gov.hmrc.tradereportingextracts.models.sdes.{FileNotificationMetadata, FileNotificationResponse}
-import uk.gov.hmrc.tradereportingextracts.models.{FileNotification as TreFileNotification, ReportRequest, ReportTypeName}
+import uk.gov.hmrc.tradereportingextracts.models.{ReportRequest, ReportTypeName, FileNotification as TreFileNotification}
 import uk.gov.hmrc.tradereportingextracts.utils.WireMockHelper
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -65,7 +64,23 @@ class FileNotificationServiceSpec
       FileNotificationMetadata.MDTPReportXCorrelationIDMetadataItem("asfd-asdf-asdf"),
       FileNotificationMetadata.MDTPReportRequestIDMetadataItem("RE123456"),
       FileNotificationMetadata.MDTPReportTypeNameMetadataItem("IMPORTS_HEADER_REPORT"),
-      FileNotificationMetadata.ReportFilesPartsMetadataItem("1of2")
+      FileNotificationMetadata.ReportFilesPartsMetadataItem("1")
+    )
+  )
+
+  val completeFileNotification: FileNotificationResponse = FileNotificationResponse(
+    eori = "GB123456789012",
+    fileName = "testFileName",
+    fileSize = 12345,
+    metadata = List(
+      FileNotificationMetadata.RetentionDaysMetadataItem("30"),
+      FileNotificationMetadata.FileTypeMetadataItem("CSV"),
+      FileNotificationMetadata.EORIMetadataItem("GB123456789012"),
+      FileNotificationMetadata.MDTPReportXCorrelationIDMetadataItem("asfd-asdf-asdf"),
+      FileNotificationMetadata.MDTPReportRequestIDMetadataItem("RE123456"),
+      FileNotificationMetadata.MDTPReportTypeNameMetadataItem("IMPORTS_HEADER_REPORT"),
+      FileNotificationMetadata.ReportFilesPartsMetadataItem("1"),
+      FileNotificationMetadata.ReportLastFileMetadataItem("true")
     )
   )
 
@@ -176,11 +191,10 @@ class FileNotificationServiceSpec
         .thenReturn(Future.successful(Some(reportWithUserEmail)))
       when(mockReportRequestService.update(any())(any()))
         .thenReturn(Future.successful(true))
-      when(mockReportRequestService.determineReportStatus(any())).thenReturn(COMPLETE)
       when(mockEmailConnector.sendEmailRequest(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
-      val result = service.processFileNotification(fileNotification)
+      val result = service.processFileNotification(completeFileNotification)
       whenReady(result) { _ =>
         verify(mockEmailConnector).sendEmailRequest(
           eqTo("tre_report_available"),
@@ -210,11 +224,10 @@ class FileNotificationServiceSpec
         .thenReturn(Future.successful(Some(reportWithRecipients)))
       when(mockReportRequestService.update(any())(any()))
         .thenReturn(Future.successful(true))
-      when(mockReportRequestService.determineReportStatus(any())).thenReturn(COMPLETE)
       when(mockEmailConnector.sendEmailRequest(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
-      val result = service.processFileNotification(fileNotification)
+      val result = service.processFileNotification(completeFileNotification)
       whenReady(result) { _ =>
         verify(mockEmailConnector).sendEmailRequest(
           eqTo("tre_report_available_non_verified"),
@@ -238,11 +251,10 @@ class FileNotificationServiceSpec
         .thenReturn(Future.successful(Some(reportNoUserEmail)))
       when(mockReportRequestService.update(any())(any()))
         .thenReturn(Future.successful(true))
-      when(mockReportRequestService.determineReportStatus(any())).thenReturn(COMPLETE)
       when(mockEmailConnector.sendEmailRequest(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
-      val result = service.processFileNotification(fileNotification)
+      val result = service.processFileNotification(completeFileNotification)
       whenReady(result) { _ =>
         verify(mockEmailConnector, never).sendEmailRequest(
           eqTo("tre_report_available"),
@@ -266,13 +278,12 @@ class FileNotificationServiceSpec
         .thenReturn(Future.successful(Some(maskedReportRequest)))
       when(mockReportRequestService.update(any())(any()))
         .thenReturn(Future.successful(true))
-      when(mockReportRequestService.determineReportStatus(any())).thenReturn(COMPLETE)
       when(mockEmailConnector.sendEmailRequest(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
       val result = service.processFileNotification(
         fileNotification.copy(
-          metadata = fileNotification.metadata.map {
+          metadata = completeFileNotification.metadata.map {
             case FileNotificationMetadata.MDTPReportRequestIDMetadataItem(_) =>
               FileNotificationMetadata.MDTPReportRequestIDMetadataItem("12345-6789")
             case m                                                           => m

--- a/test/uk/gov/hmrc/tradereportingextracts/services/FileNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/tradereportingextracts/services/FileNotificationServiceSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.crypto.Sensitive.SensitiveString
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tradereportingextracts.connectors.EmailConnector
 import uk.gov.hmrc.tradereportingextracts.models.sdes.{FileNotificationMetadata, FileNotificationResponse}
-import uk.gov.hmrc.tradereportingextracts.models.{ReportRequest, ReportTypeName, FileNotification as TreFileNotification}
+import uk.gov.hmrc.tradereportingextracts.models.{FileNotification as TreFileNotification, ReportRequest, ReportTypeName}
 import uk.gov.hmrc.tradereportingextracts.utils.WireMockHelper
 
 import scala.concurrent.{ExecutionContext, Future}


### PR DESCRIPTION
### Changes include

- Using `_isReportStatusComplete_` of `_ReportRequest_` model to check if the report is complete. (previously using `determineReportStatus` method of service class is not capable and will never return **COMPLETE**)
- 
- Replaced deprecated Mdc import with latest _uk.gov.hmrc.mdc.Mdc_ one.
- 
- Removed unwanted parenthesis on `_isReportStatusComplete_` method
- 
- Made corrections on  `FileNotificationServiceSpec` file 